### PR TITLE
Update tools to point to OCDSKit, not BODSKit

### DIFF
--- a/compiling_schema.md
+++ b/compiling_schema.md
@@ -1,7 +1,7 @@
 # Maintenance and compilation of the BODS schema
 
 ## Codelists
-_[We maintain codelists as csv files so that we can included metadata for codelist items. We should document here what the workflow is around updating them and embedding codelist items as enums in the schema. OCDSkit has 'set-closed-codelist-enums' (Sets the enum in a JSON Schema to match the codes in the CSV files of closed codelists). Does BODSkit have sthg similar, should it? And should compilation (below) call on that operation?]_
+_[We maintain codelists as csv files so that we can included metadata for codelist items. We should document here what the workflow is around updating them and embedding codelist items as enums in the schema. OCDSkit has 'set-closed-codelist-enums' (Sets the enum in a JSON Schema to match the codes in the CSV files of closed codelists). Will that work with BODS as-is and if so, should compilation (below) call on that operation?]_
 
 
 ## Compilation

--- a/tools.md
+++ b/tools.md
@@ -14,10 +14,57 @@ Flatten-Tool enables a dataset to be round-tripped between structured JSON and t
 
 [ [Flatten Tool documentation](https://flatten-tool.readthedocs.io/en/latest/usage-bods/) | [Repository](https://github.com/OpenDataServices/flatten-tool) ]
 
+## Tools for producing an updated field mapper
+
+[BODSkit](https://github.com/openownership/bodskit) used to contain various
+software tools which could be used when working on the field mapping spreadsheet.
+
+That repository has since been archived, because all of the tools could be
+found elsewhere, either in other open-source packages or in OCDSkit.
+
+Here are the replacements for the existing tooling:
+
+### Extracting a spreadsheet with all of the fields from the schema
+
+Before:
+
+`bodskit mapping-sheet ~/work/openownership-data-standard/schema/person-statement.json > out.csv`
+
+Now:
+
+`ocdskit mapping-sheet --order-by path ~/work/openownership-data-standard/schema/person-statement.json > out.csv`
+
+### Combining all codelist CSVs into a single file
+
+Before:
+
+`bodskit all-codes ~/work/openownership-data-standard/schema/codelists > out.csv`
+
+Now:
+
+```shell
+pip install csvkit
+cd path/to/data-standard
+csvstack --filenames -n codelist schema/codelists/* | sed s/\.csv// | in2csv -f csv
+```
+
+### Report open and closed codelists in a schema
+
+Before:
+
+`bodskit schema-codelist-report ~/work/openownership-data-standard/schema/person-statement.json`
+
+Now:
+
+`ocdskit schema-report --no-definitions ~/work/openownership-data-standard/schema/person-statement.json`
+
+(Note the `type` column now becomes a boolean `openCodeList` column, but the
+meaning is identical)
+
 ## Locally running CoVE checks on the command line for schema development
 _This is a hacky way of doing things. Please edit with any improved process_
 
-**Goal:** run command line validation and additional checks of example data against dev version of schema.  
+**Goal:** run command line validation and additional checks of example data against dev version of schema.
 
 * have some kind of virtual environment for doing BODS things in;
 * git clone and install [lib-cove-bods](https://github.com/openownership/lib-cove-bods) using `pip -r requirements.txt`;

--- a/tools.md
+++ b/tools.md
@@ -4,10 +4,10 @@
 
 BODS docs are published on [readthedocs](http://standard.openownership.org).
 
-## BODSkit
-BODSkit provides command line tools for common development tasks.
+## OCDSKit
+OCDSkit provides command line tools for common development tasks, which can also be used with BODS.
 
-[ [BODSkit documentation](https://bodskit.readthedocs.io/en/master/cli.html) | [Repository](https://github.com/openownership/bodskit) ]
+[ [OCDSkit documentation](https://ocdskit.readthedocs.io/en/master/cli.html) | [Repository](https://github.com/openownership/ocdskit) ]
 
 ## Flatten Tool for BODS
 Flatten-Tool enables a dataset to be round-tripped between structured JSON and tabular data packages, CSV files, or spreadsheets.


### PR DESCRIPTION
See companion PR in BODSKit https://github.com/openownership/bodskit/pull/15 and https://github.com/openownership/bodskit/issues/14 for rationale behind this. 

Once that PR is accepted and the repo archived, this should be merged to make sure our docs are up to date.