### PR TITLE
New freeze checklist

### DIFF
--- a/standard_releases.md
+++ b/standard_releases.md
@@ -233,11 +233,13 @@ are:
 ## Freeze checklist
 
 1. Ensure that all pages in the docs/about/ directory have been reviewed and updated if necessary.
-2. Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
-3. Update BODS version ‘attention’ box on all relevant docs pages
-4. Do a final edit of docs/schema/changelog.rst
-5. Fix any sphinx build warnings or errors (including broken links)
-6. Update all example and test BODS json data to increment `bodsVersion` value
-7. Update the `version` field value in all schema .json files
-8. Update docs/conf.py
-9. Run pytest finally, and resolve any errors.
+2. Update the license file (root of repo).
+3. Update the ReadMe file (root of repo).
+4. Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
+5. Update BODS version ‘attention’ box on all relevant docs pages
+6. Do a final edit of docs/schema/changelog.rst
+7. Fix any sphinx build warnings or errors (including broken links)
+8. Update all example and test BODS json data to increment `bodsVersion` value
+9. Update the `version` field value in all schema .json files
+10. Update docs/conf.py and check the docs build without errors.
+11. Run pytest finally, and resolve any errors.

--- a/standard_releases.md
+++ b/standard_releases.md
@@ -232,12 +232,12 @@ are:
 
 ## Freeze checklist
 
-* Ensure that all pages in docs/about.rst have been reviewed and updated if necessary.
-* Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
-* Update BODS version ‘attention’ box on all relevant docs pages
-* Do a final edit of docs/schema/changelog.rst
-* Fix any sphinx build warnings or errors (including broken links)
-* Update all example and test BODS json data to increment `bodsVersion` value
-* Update the `version` field value in all schema .json files
-* Update docs/conf.py
-* Run pytest finally, and resolve any errors.
+1. Ensure that all pages in docs/about.rst have been reviewed and updated if necessary.
+2. Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
+3. Update BODS version ‘attention’ box on all relevant docs pages
+4. Do a final edit of docs/schema/changelog.rst
+5. Fix any sphinx build warnings or errors (including broken links)
+6. Update all example and test BODS json data to increment `bodsVersion` value
+7. Update the `version` field value in all schema .json files
+8. Update docs/conf.py
+9. Run pytest finally, and resolve any errors.

--- a/standard_releases.md
+++ b/standard_releases.md
@@ -88,6 +88,7 @@ least work! The general process is:
   likely already been merged in the course of normal development, but they may
   need additional development, examples adding, etc.
 * Review, test and merge those changes into the `master` branch.
+* Go through the [Freeze checklist](#freeze-checklist) (below) and ensure that all elements of the docs and schema have been updated and tested as outlined.
 * Call a "freeze" on the master branch. This freeze lasts during the translation
   process and applies to the schema and docs folders in the repository.
 * Create a new branch from `master` for the translation work. e.g.
@@ -228,3 +229,15 @@ In general, the process for these kinds of changes should be:
 are:
 * LICENSE
 * docs/about (particularly licensing and privacy info)
+
+## Freeze checklist
+
+* Ensure that all pages in docs/about.rst have been reviewed and updated if necessary.
+* Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
+* Update BODS version ‘attention’ box on all relevant docs pages
+* Do a final edit of docs/schema/changelog.rst
+* Fix any sphinx build warnings or errors (including broken links)
+* Update all example and test BODS json data to increment `bodsVersion` value
+* Update the `version` field value in all schema .json files
+* Update docs/conf.py
+* Run pytest finally, and resolve any errors.

--- a/standard_releases.md
+++ b/standard_releases.md
@@ -239,8 +239,8 @@ are:
 5. Update BODS version ‘attention’ box on all relevant docs pages
 6. Do a final edit of docs/schema/changelog.rst
 7. Fix any sphinx build warnings or errors (including broken links)
-8. Update all example and test BODS json data to increment `bodsVersion` value
+8. Update all example and test BODS json data to increment `bodsVersion` value. (And 'bodsVersionTypo' in one test file.)
 9. Update the `version` field value in all schema .json files
-10. Update the version info in the title of index.rst (home page of the docs).
+10. Update the two version references in index.rst (home page of the docs).
 11. Update docs/conf.py and check the docs build without errors.
 12. Run pytest finally, and resolve any errors.

--- a/standard_releases.md
+++ b/standard_releases.md
@@ -241,5 +241,6 @@ are:
 7. Fix any sphinx build warnings or errors (including broken links)
 8. Update all example and test BODS json data to increment `bodsVersion` value
 9. Update the `version` field value in all schema .json files
-10. Update docs/conf.py and check the docs build without errors.
-11. Run pytest finally, and resolve any errors.
+10. Update the version info in the title of index.rst (home page of the docs).
+11. Update docs/conf.py and check the docs build without errors.
+12. Run pytest finally, and resolve any errors.

--- a/standard_releases.md
+++ b/standard_releases.md
@@ -232,7 +232,7 @@ are:
 
 ## Freeze checklist
 
-1. Ensure that all pages in docs/about.rst have been reviewed and updated if necessary.
+1. Ensure that all pages in the docs/about/ directory have been reviewed and updated if necessary.
 2. Check docs/schema/reference.rst. Are all new objects, properties and codelists there? Have sub-properties been collapsed sensibly?
 3. Update BODS version ‘attention’ box on all relevant docs pages
 4. Do a final edit of docs/schema/changelog.rst


### PR DESCRIPTION
These edits outline the steps we went through for the BODS 0.3 freeze. The checklist isn't the place for detailed instructions on how to do each item. (Issues #8 and #38, for example, note where more information should be documented.)  