### PR TITLE
translation guidance from data standard readme added

### DIFF
--- a/translations.md
+++ b/translations.md
@@ -172,6 +172,25 @@ locale_dirs = ['locale/', os.path.join(oods.sphinxtheme.get_html_theme_path(), '
 
 So make sure the latest version of the theme is being installed in case expected translations aren't showing up.
 
+### Creating and configuring a new project in Transifex
+
+Translations for the current latest version of BODS are found in the [BODS-main Transifex project](https://www.transifex.com/OpenDataServices/bods-main). These may not be updated until it is time for a new versioned release of BODS, meaning translations in Transifex may be lagging behind the latest text in the BODS Github repository. However, when changes to the docs, schema or codelists are merged into the main branch, these changes should always be pushed to Transifex, so that - assuming translators are available - translations can be brought up to date at any time. See [integrating translations](#integrating-translations).
+
+If you need to create a new Transifex project that contains the latest available source files and translations, do the following:
+
+* [Add a new project on Transifex](https://www.transifex.com/OpenDataServices/add/).
+* If applicable, name it according to the version of BODS, e.g. `bods-v02` for BODS version 0.2.
+* Choose 'public project' and **make sure to check the 'My project is a non-commercial Open Source project checkbox'** and enter the Github repo URL.
+* ![Screenshot: tick the My project is a non-commercial Open Source project checkbox when creating a new project](screenshots/translation/transifex_noncommercial.png)
+* Assign the project to the BODS team.
+* Under the 'Workflow' tab choose "Translation Memory Fill-up" under "Pre-translation".
+* ![Screenshot: tick the  "Translation Memory Fill-up" under "Pre-translation" when creating a new project](/screenshots/translation/transifex_translation_memory.png)
+* Make sure you have the latest translations and source files in your local environment (see the [translation workflow](#translation-workflow).
+* Update the Transifex config to use the Transifex project that you just created (see the [translation workflow](#translation-workflow)). Commit this change if you want all subsequent updates to the branch you are on to use the new Transifex project.
+* Run `tx push -s` to push the source files to Transifex.
+* Run `tx push -t` to push the translation files to Transifex.
+  * Transifex only lets you push translations if it detects yours are newer than what it already has, but sometimes this fails - especially if you are pushing to an empty project. You can force it to accept translations from your local environment with `tx push -t -f` - you will have to confirm (press `y` and <enter>) each file by hand. Note that this will override anything already in Transifex, so make sure yours really are the latest.
+
 ### Translation workflow
 
 To run the steps in the translation workflow, ensure that you have followed the installation and setup instructions above.
@@ -230,26 +249,6 @@ itstool -m docs/locale/<LANG>/LC_MESSAGES/svg.mo -o docs/_build_svgs/<LANG> docs
 ```
 
 7. **Make a PR** with the new translation files and SVGs (if applicable).
-
-
-### Creating and configuring a new project in Transifex
-
-Translations for the current latest version of BODS are found in the [BODS-main Transifex project](https://www.transifex.com/OpenDataServices/bods-main). These may not be updated until it is time for a new versioned release of BODS, meaning translations in Transifex may be lagging behind the latest text in the BODS Github repository. However, when changes to the docs, schema or codelists are merged into the main branch, these changes should always be pushed to Transifex, so that - assuming translators are available - translations can be brought up to date at any time. See [integrating translations](#integrating-translations).
-
-If you need to create a new Transifex project that contains the latest available source files and translations, do the following:
-
-* [Add a new project on Transifex](https://www.transifex.com/OpenDataServices/add/).
-* If applicable, name it according to the version of BODS, e.g. `bods-v02` for BODS version 0.2.
-* Choose 'public project' and **make sure to check the 'My project is a non-commercial Open Source project checkbox'** and enter the Github repo URL.
-* ![Screenshot: tick the My project is a non-commercial Open Source project checkbox when creating a new project](screenshots/translation/transifex_noncommercial.png)
-* Assign the project to the BODS team.
-* Under the 'Workflow' tab choose "Translation Memory Fill-up" under "Pre-translation".
-* ![Screenshot: tick the  "Translation Memory Fill-up" under "Pre-translation" when creating a new project](/screenshots/translation/transifex_translation_memory.png)
-* Make sure you have the latest translations and source files in your local environment (see the [translation workflow](#translation-workflow).
-* Update the Transifex config to use the Transifex project that you just created (see the [translation workflow](#translation-workflow)). Commit this change if you want all subsequent updates to the branch you are on to use the new Transifex project.
-* Run `tx push -s` to push the source files to Transifex.
-* Run `tx push -t` to push the translation files to Transifex.
-  * Transifex only lets you push translations if it detects yours are newer than what it already has, but sometimes this fails - especially if you are pushing to an empty project. You can force it to accept translations from your local environment with `tx push -t -f` - you will have to confirm (press `y` and <enter>) each file by hand. Note that this will override anything already in Transifex, so make sure yours really are the latest.
 
 ### Teams and Roles
 

--- a/translations.md
+++ b/translations.md
@@ -98,6 +98,16 @@ $ sudo apt-get install python-pip
 $ sudo pip install transifex-client
 ```
 
+#### Installing other dependencies
+
+You also need to make sure you have `gettext`, `pybabel` and (for SVGs) `itstool` installed in whatever environment you're running this in:
+
+```
+$ apt-get install gettext
+$ apt-get install python3-babel
+$ apt-get install itstool
+```
+
 #### Configuring the Transifex client
 
 Transifex configuration involves the creation of two files:
@@ -139,13 +149,16 @@ The diagram below shows the state of the .tx/config file after extracting the st
 
 ![Github-Transifex config](/screenshots/translation/github_transifex_config.png)
 
-To create an initial `.tx/config` file follow the instructions in the [data-standard repo](https://github.com/openownership/data-standard)
+Instructions to create an initial `.tx/config` file are provided [below](#translation-workflow).
+
 
 ## Integrating translations
 
 Whenever any strings are changed that are in scope for translation (see list above) they need to be 'extracted', pushed to Transifex, translated, and the translated strings pulled back down. Updates to the documentation and schema should not be released until the necessary translations are in place.
 
-The steps for doing this should be done by the person making the changes to the schema and docs, and are documented in the [data standard README](https://github.com/openownership/data-standard/blob/master/README.md#managing-the-translation-workflow). There are separate steps for the docs, schema and codelists, and you only need to carry out the steps applicable to the changes you made. For example, if you only updated the schema, you don't need to execute commands to extract strings from the docs or codelists.
+If you are working on a development branch, you **should not** push source file changes to Transifex. Instead, wait until your changes have been merged into the main branch. **Source files should only ever be pushed to Transifex from the main branch** (currently `master`) to ensure conflicts do not occur in Transifex between multiple people working on different branches simultaneously.
+
+The steps for doing this should be done by the person making the changes to the schema and docs, and are documented [below](#translation-workflow). There are separate steps for the docs, schema and codelists, and you only need to carry out the steps applicable to the changes you made. For example, if you only updated the schema, you don't need to execute commands to extract strings from the docs or codelists.
 
 If you are working on a development branch, you **should not** push source file changes to Transifex. Instead, wait until your changes have been merged into the main branch. **Source files should only ever be pushed to Transifex from the main branch** (currently `master`) to ensure conflicts do not occur in Transifex between multiple people working on different branches simultaneously.
 
@@ -161,6 +174,66 @@ locale_dirs = ['locale/', os.path.join(oods.sphinxtheme.get_html_theme_path(), '
 
 So make sure the latest version of the theme is being installed in case expected translations aren't showing up.
 
+### Translation workflow
+
+To run the steps in the translation workflow, ensure that you have followed the installation and setup instructions above.
+
+Run the following commands from the root directory unless otherwise specified (eg. sometimes it's less complicated to run them from `docs`).
+
+0. *Before you start*, run `tx pull -a` to make sure you have the most up to date translations in your local environment.
+
+**When you change text in the docs** you need to do the following so that they can be translated:
+
+* From the `docs` directory, run `make gettext` to extract translatable English strings from the docs. (This generates `.pot` files into `docs/_build/gettext/`.)
+
+**If you modified the schema** also:
+
+* Run `pybabel extract -F babel_bods_schema.cfg . -o docs/_build/gettext/schema.pot` to extract translatable English strings from the schema.
+
+**If you modified the codelists** also:
+
+* Run `pybabel extract -F babel_bods_codelist.cfg . -o docs/_build/gettext/codelist.pot` to extract translatable English strings from the codelists.
+* If you change (add, remove, rename) a column heading in a codelist CSV, you must also edit the `babel_bods_codelist.cfg` file to match.
+
+**If you modified an SVG diagram** also:
+
+* Run `itstool -i svg-its-rules.xml -o docs/_build/gettext/svg.pot docs/_assets/*.svg` to extract translatable English strings from the SVGs.
+
+**If you added, deleted or renamed** files or you want to use a **different Transifex project**, run (from root, ie. `cd ../`):
+
+```
+rm -f .tx/config
+sphinx-intl create-txconfig
+sphinx-intl update-txconfig-resources --pot-dir docs/_build/gettext --locale-dir docs/locale --transifex-project-name bods-test
+```
+
+(Replacing `bods-test` with a different Transifex project name.)
+
+And then:
+
+3. Run `tx push -s` to **push to Transifex**.
+
+Now the files are ready to be translated in Transifex.
+
+4. **To fetch new translations** when they're done, you need to run `tx pull -a` to fetch all, or `tx pull -l ru` to fetch a particular language.
+
+5. If you are still on the main branch, check out a new development branch from which you will make a PR with the updated translations. **Commit** the new or updated .po files in `docs/locale`.
+
+6. **Build translated SVGs** for each language using itstool, and commit these (because we can't easily install itstool on readthedocs):
+
+```
+pybabel compile --use-fuzzy -d docs/locale -D svg
+```
+
+Replacing <LANG> with language code, eg, `ru` (run this once per language):
+
+```
+itstool -m docs/locale/<LANG>/LC_MESSAGES/svg.mo -o docs/_build_svgs/<LANG> docs/_assets/*.svg
+```
+
+7. **Make a PR** with the new translation files and SVGs (if applicable).
+
+
 ### Creating and configuring a new project in Transifex
 
 Translations for the current latest version of BODS are found in the [BODS-main Transifex project](https://www.transifex.com/OpenDataServices/bods-main). These may not be updated until it is time for a new versioned release of BODS, meaning translations in Transifex may be lagging behind the latest text in the BODS Github repository. However, when changes to the docs, schema or codelists are merged into the main branch, these changes should always be pushed to Transifex, so that - assuming translators are available - translations can be brought up to date at any time. See [integrating translations](#integrating-translations).
@@ -174,8 +247,8 @@ If you need to create a new Transifex project that contains the latest available
 * Assign the project to the BODS team.
 * Under the 'Workflow' tab choose "Translation Memory Fill-up" under "Pre-translation".
 * ![Screenshot: tick the  "Translation Memory Fill-up" under "Pre-translation" when creating a new project](/screenshots/translation/transifex_translation_memory.png)
-* Make sure you have the latest translations and source files in your local environment (see the [translation process](https://github.com/openownership/data-standard/blob/master/README.md#managing-the-translation-workflow)).
-* Update the Transifex config to use the Transifex project that you just created (see the [translation process](https://github.com/openownership/data-standard/blob/master/README.md#managing-the-translation-workflow)). Commit this change if you want all subsequent updates to the branch you are on to use the new Transifex project.
+* Make sure you have the latest translations and source files in your local environment (see the [translation workflow](#translation-workflow).
+* Update the Transifex config to use the Transifex project that you just created (see the [translation workflow](#translation-workflow)). Commit this change if you want all subsequent updates to the branch you are on to use the new Transifex project.
 * Run `tx push -s` to push the source files to Transifex.
 * Run `tx push -t` to push the translation files to Transifex.
   * Transifex only lets you push translations if it detects yours are newer than what it already has, but sometimes this fails - especially if you are pushing to an empty project. You can force it to accept translations from your local environment with `tx push -t -f` - you will have to confirm (press `y` and <enter>) each file by hand. Note that this will override anything already in Transifex, so make sure yours really are the latest.

--- a/translations.md
+++ b/translations.md
@@ -156,8 +156,6 @@ Instructions to create an initial `.tx/config` file are provided [below](#transl
 
 Whenever any strings are changed that are in scope for translation (see list above) they need to be 'extracted', pushed to Transifex, translated, and the translated strings pulled back down. Updates to the documentation and schema should not be released until the necessary translations are in place.
 
-If you are working on a development branch, you **should not** push source file changes to Transifex. Instead, wait until your changes have been merged into the main branch. **Source files should only ever be pushed to Transifex from the main branch** (currently `master`) to ensure conflicts do not occur in Transifex between multiple people working on different branches simultaneously.
-
 The steps for doing this should be done by the person making the changes to the schema and docs, and are documented [below](#translation-workflow). There are separate steps for the docs, schema and codelists, and you only need to carry out the steps applicable to the changes you made. For example, if you only updated the schema, you don't need to execute commands to extract strings from the docs or codelists.
 
 If you are working on a development branch, you **should not** push source file changes to Transifex. Instead, wait until your changes have been merged into the main branch. **Source files should only ever be pushed to Transifex from the main branch** (currently `master`) to ensure conflicts do not occur in Transifex between multiple people working on different branches simultaneously.


### PR DESCRIPTION
Resolves issue [398](https://github.com/openownership/data-standard/issues/398) from the data standard repo. Note that I haven't done a full edit of the guidance, but have just added the text from the data standard readme and removed from there. Also had to change various hyperlinks etc and slightly alter structure to make it readable with the new section added