### PR TITLE
removing caps from boolean in min test statement

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -106,7 +106,7 @@ A minimum valid BODS entity statement looks like this:
         "recordType": "entity",
         "recordDetails": {
             "entityType": "unknownEntity",
-            "isComponent": False,
+            "isComponent": false,
         },
     }
 ]


### PR DESCRIPTION
removing caps from boolean in minimum valid BODS entity statement example, to be in line with JSON schema.